### PR TITLE
Change CSS not to apply values to al links

### DIFF
--- a/nice-date-picker.css
+++ b/nice-date-picker.css
@@ -11,7 +11,7 @@
     font-size:0;
     position:relative;
 }
-.nice-date-picker-header span,a{
+.nice-date-picker-header span,.nice-date-picker-header a{
     display:inline-block;
     height:40px;
     line-height:40px;


### PR DESCRIPTION
Previous CSS changed all "a" elements, now only ".nice-date-picker-header a" elements are changed.